### PR TITLE
SAHM 1.1 Updates for Mac OS X

### DIFF
--- a/SahmOutputViewer.py
+++ b/SahmOutputViewer.py
@@ -232,10 +232,13 @@ class SAHMOutputViewerCellWidget(QCellWidget):
         self.gs_variable_graph.wheelEvent = self.wheel_event_variable
         
         #add in ie browsers for the text and response
-        self.text_browser = QAxContainer.QAxWidget(self)
-        self.text_browser.setFocusPolicy(QtCore.Qt.StrongFocus)
-        self.text_browser.setControl("{8856F961-340A-11D0-A96B-00C04FD705A2}")
-        self.ui.text_output_layout.addWidget(self.text_browser)
+        if systemType in ['Microsoft', 'Windows']:
+            self.text_browser = QAxContainer.QAxWidget(self)
+            self.text_browser.setFocusPolicy(QtCore.Qt.StrongFocus)
+            self.text_browser.setControl("{8856F961-340A-11D0-A96B-00C04FD705A2}")
+            self.ui.text_output_layout.addWidget(self.text_browser)
+        else:
+            self.text_browser = None
         self.text_urlSrc = None
         
 #        layout = QtGui.QVBoxLayout()
@@ -404,10 +407,11 @@ class SAHMOutputViewerCellWidget(QCellWidget):
                                        max_size]
 
         self.text_urlSrc = QtCore.QUrl.fromLocalFile(text_output.name)
-        if self.text_urlSrc!=None:
-            self.text_browser.dynamicCall('Navigate(const QString&)', self.text_urlSrc.toString())
-        else:
-            self.text_browser.dynamicCall('Navigate(const QString&)', QtCore.QString('about:blank'))
+        if self.text_browser is not None:
+            if self.text_urlSrc!=None:
+                self.text_browser.dynamicCall('Navigate(const QString&)', self.text_urlSrc.toString())
+            else:
+                self.text_browser.dynamicCall('Navigate(const QString&)', QtCore.QString('about:blank'))
         
        
         choices = ['Text', 'Response Curves', 'AUC', 'Calibration', 'Confusion', 'Residuals','Variable Importance']

--- a/SahmSpatialOutputViewer.py
+++ b/SahmSpatialOutputViewer.py
@@ -54,9 +54,6 @@ import utils
 import math
 
 from PyQt4 import QtCore, QtGui
-from core.system import systemType
-if systemType in ['Microsoft', 'Windows']:
-    from PyQt4 import QAxContainer
 from core.modules.vistrails_module import Module
 from packages.spreadsheet.basic_widgets import SpreadsheetCell, CellLocation
 from packages.spreadsheet.spreadsheet_cell import QCellWidget, QCellToolBar

--- a/pySAHM/Resources/R_Modules/CompareBkgdDists.r
+++ b/pySAHM/Resources/R_Modules/CompareBkgdDists.r
@@ -151,8 +151,8 @@ Args <- commandArgs(trailingOnly=FALSE)
     }
 
 ScriptPath<-dirname(ScriptPath)
-source(paste(ScriptPath,"chk.libs.r",sep="\\"))
-source(paste(ScriptPath,"my.panel.smooth.binary.r",sep="\\"))
+source(file.path(ScriptPath,"chk.libs.r"))
+source(file.path(ScriptPath,"my.panel.smooth.binary.r"))
 
 CompareBkgdDists(file.list,num.reps,num.pts)
 Predictor.inspection(predictor=predictor,input.file=infile,output.dir=output,response.col=responseCol,pres=TRUE,absn=TRUE,bgd=TRUE)

--- a/pySAHM/Resources/R_Modules/PairsExplore.r
+++ b/pySAHM/Resources/R_Modules/PairsExplore.r
@@ -213,10 +213,10 @@ Args <- commandArgs(trailingOnly=FALSE)
     }
  
  ScriptPath<-dirname(ScriptPath)
-source(paste(ScriptPath,"my.panel.smooth.binary.r",sep="\\"))
-source(paste(ScriptPath,"read.dat.r",sep="\\"))
-source(paste(ScriptPath,"chk.libs.r",sep="\\"))
-source(paste(ScriptPath,"PairsExploreHelperFcts.r",sep="\\"))
+source(file.path(ScriptPath, "my.panel.smooth.binary.r"))
+source(file.path(ScriptPath,"read.dat.r"))
+source(file.path(ScriptPath, "chk.libs.r"))
+source(file.path(ScriptPath,"PairsExploreHelperFcts.r"))
 	#Run the Pairs Explore function with these parameters
     Pairs.Explore(num.plots=num.plots,
     min.cor=min.cor,

--- a/pySAHM/Resources/R_Modules/PseudoAbs.r
+++ b/pySAHM/Resources/R_Modules/PseudoAbs.r
@@ -234,6 +234,6 @@ Args <- commandArgs(trailingOnly=FALSE)
 
 if(method=="MCP") continuous=FALSE
 ScriptPath<-dirname(ScriptPath)
-source(paste(ScriptPath,"chk.libs.r",sep="\\"))
+source(file.path(ScriptPath,"chk.libs.r"))
 
 PseudoAbsGen(input.file=infile,outfile=output,method=method,bw.otim=bw.opt,isopleth=ispt,bias=continuous,template=template)

--- a/pySAHM/Resources/R_Modules/SetWeights.r
+++ b/pySAHM/Resources/R_Modules/SetWeights.r
@@ -56,8 +56,9 @@ SetWeights<-function(input.file,output.file,response.col="ResponseBinary",method
 #Written by Marian Talbert 12/7/2011
 
          #strip the directory out of the output file and replace with the weights.map (name of the map produced)
+       # DAK: this looks problematic for cross-platform operation
        last.dir<-strsplit(output.file,split="\\\\")
-       plot.name<-paste(sub(paste("\\\\",last.dir[[1]][length(last.dir[[1]])],sep=""),"",output.file),"weights.map.jpg",sep="\\")
+       plot.name<-file.path(sub(paste("\\\\",last.dir[[1]][length(last.dir[[1]])],sep=""),"",output.file),"weights.map.jpg")
    #Read input data and remove any columns to be excluded
           dat.in<-read.csv(input.file,header=FALSE,as.is=TRUE)
           dat<-as.data.frame(dat.in[4:dim(dat.in)[1],])

--- a/pySAHM/Resources/R_Modules/proc.tiff.r
+++ b/pySAHM/Resources/R_Modules/proc.tiff.r
@@ -142,15 +142,14 @@ proc.tiff<- function(model,vnames,tif.dir=NULL,filenames=NULL,factor.levels=NA,m
       library(parallel)
       #create some temporary folders    
       if(make.p.tif)
-        dir.create(paste(out$input$output.dir,"\\ProbTiff",sep=""))
-        outfile.p=paste(paste(out$input$output.dir,"\\ProbTiff\\",sep=""),"_prob_map.tif",sep="")
+        dir.create(file.path(out$input$output.dir,"ProbTiff"))
+        outfile.p=file.path(out$input$output.dir,"ProbTiff","_prob_map.tif")
       if(make.binary.tif)                                                                                         
-        outfile.bin=dir.create(paste(out$input$output.dir,"\\BinTiff",sep=""))
-      if(MESS) dir.create(paste(out$input$output.dir,"\\MESSTiff",sep="")) 
-      if(MOD)  dir.create(paste(out$input$output.dir,"\\ModTiff",sep=""))       
-           
+        outfile.bin=dir.create(file.path(out$input$output.dir,"BinTiff"))
+      if(MESS) dir.create(file.path(out$input$output.dir,"MESSTiff"))
+      if(MOD)  dir.create(file.path(out$input$output.dir,"ModTiff"))
        if(out$input$ResidMaps)
-        dir.create(paste(out$input$output.dir,"\\ResidTiff",sep=""))
+        dir.create(file.path(out$input$output.dir,"ResidTiff"))
         tile.start<-seq(from=1,to=tr$n,by=ceiling(tr$n/(detectCores()-1))) 
       cl <- makeCluster(detectCores()) 
       parLapply(cl,X=tile.start,fun=parRaster,dims=dims,

--- a/pySAHM/Resources/R_Modules/response.curves.r
+++ b/pySAHM/Resources/R_Modules/response.curves.r
@@ -71,14 +71,14 @@ response.curves<-function(out,Model,pred.dat=NULL,cv=FALSE){
             }
     }
        
-     dir.create(paste(out$input$output.dir,"\\responseCurves",sep=""))
+     dir.create(file.path(out$input$output.dir,"responseCurves"))
      rsp.dat<-NA
       
       for (k in c(1,2)){
-          if(k==1){ jpeg(paste(out$input$output.dir,"\\responseCurves\\","all_response_curves.jpg",sep=""),width=2000,height=2000,quality=100)
+          if(k==1){ jpeg(file.path(out$input$output.dir,"responseCurves","all_response_curves.jpg"),width=2000,height=2000,quality=100)
                     par(oma=c(2,2,4,2),mfrow=c(prow,pcol))}                   
          for (i in sort(match(out$mods$vnames,names(dat)))) {
-                if (k==2) jpeg(filename=paste(out$input$output.dir,"\\responseCurves\\",names(dat)[i],".jpg",sep=""),width=2000,height=2000,quality=100)
+                if (k==2) jpeg(filename=file.path(out$input$output.dir,"responseCurves",paste(names(dat)[i],".jpg",sep="")),width=2000,height=2000,quality=100)
                 if (!is.factor(dat[, i])) {
                     xr <- range(dat[, i])
                     Xp1 <- Xp

--- a/utils.py
+++ b/utils.py
@@ -307,7 +307,7 @@ def checkModelCovariatenames(MDSFile):
     contain any special characters besides "." and "_"
     """
     MDSisOK = True
-    covariates = open(MDSFile, "r").readline().split(",")[3:]
+    covariates = open(MDSFile, "r").readline().strip().split(",")[3:]
     for covariate in covariates:
         if not covariate[0].isalpha():
             return False


### PR DESCRIPTION
Some updates that should make the tutorial run smoother on Mac OS X 10.8.  The QAxContainer and file.path changes are self-explanatory.  The strip() addition is because of the line endings differences between Mac/Windows---strip removes the entire line ending.
